### PR TITLE
Correct battery capacity

### DIFF
--- a/overlay/frameworks/base/core/res/res/xml/power_profile.xml
+++ b/overlay/frameworks/base/core/res/res/xml/power_profile.xml
@@ -37,5 +37,5 @@
     </array>
     <item name="cpu.awake">93</item>
     <item name="cpu.idle">4.23</item>
-    <item name="battery.capacity">5000</item>
+    <item name="battery.capacity">5100</item>
 </device>


### PR DESCRIPTION
Hello,

battery.capacity is set to 5000. The correct value is probably 5100, since Lenovo P2 has a battery capacity of 5100 mAh. This value is used in the device configuration for p2a42 in AICP: https://github.com/AICP/device_lenovo_p2a42/blob/n7.1/overlay/frameworks/base/core/res/res/xml/power_profile.xml

FireLord, I'm silently using your work in a custom build of AICP. Still too early to report issues.
Thank you very much! 