### PR TITLE
overlay: Enable data for MMS

### DIFF
--- a/overlay/packages/apps/CarrierConfig/res/xml/vendor.xml
+++ b/overlay/packages/apps/CarrierConfig/res/xml/vendor.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='utf-8' standalone='yes' ?>
+<!-- This is a place for vendor-specific config values. The format and
+     filtering rules are the same as those in carrier_config*.xml files. This
+     file is read after any specific config file from the assets folder, so it
+     must use explicit filters for MCC ad MNC if that is desired. -->
+<carrier_config_list>
+    <carrier_config>
+        <boolean name="config_enable_mms_with_mobile_data_off" value="true" />
+    </carrier_config>
+</carrier_config_list>


### PR DESCRIPTION
This change makes the phone automatically enable data connection for sending and receiving MMS messages. This feature is present in stock ROM for the Lenovo P2.

Source: https://github.com/LineageOS/android_device_sony_blue-common/commit/a8bb04d77accd3d40cda09e70f133e86e8c2e8b1

I'm successfully using a custom built AICP ROM with this change. I can send and receive MMS messages while mobile data is off.